### PR TITLE
Make example compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ makeRouter ::
     }
 ```
 
-For a basic example see [`examples/RoutingDuplex.purs`](https://github.com/robertdp/purescript-wire-react-router/blob/master/examples/RoutingDuplex.purs).
+For a basic example see [`examples/RoutingDuplex.purs`](https://github.com/robertdp/purescript-wire-react-router/blob/master/examples/RoutingDuplex.purs): `$ spago build --config examples.dhall`
 
 ## How to use with Spago
 
@@ -44,3 +44,4 @@ let additions =
 
 And then install with
 `$ spago install wire-react-router`
+

--- a/examples.dhall
+++ b/examples.dhall
@@ -1,0 +1,5 @@
+{ name = "wire-react-router-examples"
+, dependencies = [ "react-basic-dom", "routing-duplex", "wire-react" ] # (./spago.dhall).dependencies
+, packages = ./packages.dhall
+, sources = [ "examples/**/*.purs", "src/**/*.purs" ]
+}

--- a/examples/RoutingDuplex.purs
+++ b/examples/RoutingDuplex.purs
@@ -7,10 +7,7 @@
 module Example.RoutingDuplex where
 
 import Prelude hiding ((/))
-import Data.Foldable (for_)
 import Data.Generic.Rep (class Generic)
-import Data.Lens (preview, review)
-import Data.Lens as Lens
 import Effect (Effect)
 import React.Basic.DOM as R
 import React.Basic.Events (handler_)
@@ -22,6 +19,7 @@ import Routing.Duplex.Generic.Syntax ((/))
 import Routing.PushState as PushState
 import Wire.React as Wire
 import Wire.React.Router as Router
+import Wire.Signal as Signal
 
 data Route
   = Home

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "purescript": "^0.13.8",
     "purescript-psa": "^0.7.3",
     "purty": "^6.2.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "spago": "^0.16.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -119,10 +119,23 @@ let additions =
 
 
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200922/packages.dhall sha256:5edc9af74593eab8834d7e324e5868a3d258bbab75c5531d2eb770d4324a2900
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20201223/packages.dhall sha256:a1a8b096175f841c4fef64c9b605fb0d691229241fd2233f6cf46e213de8a185
 
 let overrides = {=}
 
-let additions = {=}
+let additions =
+  { wire-react =
+      { dependencies =
+          [ "wire"
+          , "free"
+          , "freet"
+          , "react-basic-hooks"
+          ]
+      , repo =
+          "https://github.com/robertdp/purescript-wire-react.git"
+      , version =
+          "v0.0.1"
+      }
+  }
 
 in  upstream // overrides // additions


### PR DESCRIPTION
Hi Robert!

I'm not sure if I should push `package-lock.json` into this PR as it adds a lot of noise (I've included `react` and `react-dom` as dev dependencies).

I wonder if I should also add `webpack` as a dev dependency so we can actually run the example. What do you think?